### PR TITLE
Fixing alpha gsops compatibility issue

### DIFF
--- a/gsplat_plugin/src/GR_GSplat.C
+++ b/gsplat_plugin/src/GR_GSplat.C
@@ -136,7 +136,6 @@ GR_PrimGsplat::update(
 	{
 		alphaHandle = GA_ROHandleF(alphaAttr);
 	}
-	//(useAlphaFallback ? alphaFallbackAttr : alphaAttr);
 
 	const GA_Attribute *scaleAttr = dtl->findPointAttribute("scale");
 	if (!scaleAttr) 


### PR DESCRIPTION
Issue was occurring when both opacity and Alpha were present.