### PR TITLE
Fixing argsortByDistance name definition

### DIFF
--- a/gsplat_plugin/include/GSplatRenderer.h
+++ b/gsplat_plugin/include/GSplatRenderer.h
@@ -70,7 +70,7 @@ private:
 
     bool isRenderStateRegistryCurrent();
     bool checkSignificantDelta(const UT_Vector3F& newPos, const UT_Vector3F& oldPos, const float threshold = 0.0f);
-    bool argsortByDistance2(const UT_Vector3F *posSplatPointsData, const UT_Vector3F &ref_pos, const int pointCount);
+    bool argsortByDistance(const UT_Vector3F *posSplatPointsData, const UT_Vector3F &ref_pos, const int pointCount);
 
     void freeTextureResources();
     void initialiseTextureResources();


### PR DESCRIPTION
On a previous commit I updated `GSplatRenderer::arsortByDistance` function name from  `arsortByDistance2` to `arsortByDistance`. I had not added this file by accident, fixing it now.