### PR TITLE
Addressing linux compile issue due to missing include on GSplatLogger

### DIFF
--- a/gsplat_plugin/src/GSplatLogger.C
+++ b/gsplat_plugin/src/GSplatLogger.C
@@ -18,6 +18,7 @@
 #include <string>
 #include <sstream>
 #include <functional>
+#include <algorithm>
 
 
 void GSplatLogger::_log(const LogLevel level, const char * message)


### PR DESCRIPTION
Fixing the issue described here: https://github.com/cgnomads/GSOPs/issues/9